### PR TITLE
add 'require: false' to readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Add this line to your application's Gemfile:
 
-    gem 'capistrano3-postgres'
+    gem 'capistrano3-postgres', require: false
 
 or:
 
-    gem 'capistrano3-postgres' , group: :development
+    gem 'capistrano3-postgres', require: false, group: :development
 
 And then execute:
 


### PR DESCRIPTION
Solves https://github.com/spilin/capistrano3-postgres/issues/1

I don't think there's every a situation where you wouldn't want `require: false`?
