### PR TITLE
Evaluate ERB in database.yml, and default to assuming ident auth rather than postgres superuser

### DIFF
--- a/lib/capistrano3/tasks/postgres.rb
+++ b/lib/capistrano3/tasks/postgres.rb
@@ -119,7 +119,7 @@ namespace :postgres do
     on roles(fetch(:postgres_role)) do |role|
       run_locally do
         env = 'development'
-        yaml_content = capture "cat config/database.yml"
+        yaml_content = ERB.new(capture "cat config/database.yml").result
         set :postgres_local_database_config,  database_config_defaults.merge(YAML::load(yaml_content)[env])
       end
     end
@@ -130,7 +130,8 @@ namespace :postgres do
     return if fetch(:postgres_remote_database_config)
     on roles(fetch(:postgres_role)) do |role|
       env = fetch(:postgres_env).to_s.downcase
-      yaml_content = capture "cat #{deploy_to}/current/config/database.yml"
+      filename = "#{deploy_to}/current/config/database.yml"
+      yaml_content = capture "ruby -e \"require 'erb'; puts ERB.new(File.read('#{filename}')).result\""
       set :postgres_remote_database_config,  database_config_defaults.merge(YAML::load(yaml_content)[env])
     end
   end

--- a/lib/capistrano3/tasks/postgres.rb
+++ b/lib/capistrano3/tasks/postgres.rb
@@ -25,7 +25,7 @@ namespace :postgres do
           set :postgres_remote_sqlc_file_path, "#{shared_path}/#{fetch(:postgres_backup_dir)}/#{file_name}"
         end
 
-        execute "PGPASSWORD=#{config['password']} pg_dump -U #{config['username'] || config['user']} -h #{config['host']} -Fc --file=#{fetch(:postgres_remote_sqlc_file_path)} #{config['database']}"
+        execute "PGPASSWORD=#{config['password']} pg_dump #{user_option(config)} -h #{config['host']} -Fc --file=#{fetch(:postgres_remote_sqlc_file_path)} #{config['database']}"
       end
     end
 
@@ -64,7 +64,7 @@ namespace :postgres do
           begin
             pgpass_path = File.join(Dir.pwd, '.pgpass')
             File.open(pgpass_path, 'w+', 0600) { |file| file.write("*:*:*:#{config['username'] || config['user']}:#{config['password']}") }
-            execute "PGPASSFILE=#{pgpass_path} pg_restore -c -U #{config['username'] || config['user']} --no-owner -h #{config['host']} -p #{config['port'] || 5432 } -d #{fetch(:database_name)} #{file_path}"
+            execute "PGPASSFILE=#{pgpass_path} pg_restore -c #{user_option(config)} --no-owner -h #{config['host']} -p #{config['port'] || 5432 } -d #{fetch(:database_name)} #{file_path}"
           rescue SSHKit::Command::Failed => e
             warn e.inspect
             info 'Import performed successfully!'
@@ -113,6 +113,14 @@ namespace :postgres do
     invoke("postgres:backup:cleanup") if fetch(:postgres_keep_local_dumps) > 0
   end
 
+  def user_option(config)
+    if config['user'] || config['username']
+      "-U #{config['user'] || config['username']}"
+    else
+      '' # assume ident auth is being used
+    end
+  end
+
   # Grabs local database config before importing dump
   def grab_local_database_config
     return if fetch(:postgres_local_database_config)
@@ -137,7 +145,7 @@ namespace :postgres do
   end
 
   def database_config_defaults
-    { 'host' => 'localhost', 'user' => 'postgres' }
+    { 'host' => 'localhost' }
   end
 
 end


### PR DESCRIPTION
More detail is in the detailed commit messages for each commit. I've pasted it again here for reference:

COMMIT 1: evaluate ERB in database.yml …
Some people use erb in database.yml to evaluate environtment variables - eg password: <%= ENV["PGPASSWORD"] %>.

COMMIT 2: default to assuming ident auth rather than superuser …
Prior to this commit, if no user was specified, the 'postgres' superuser was set as a default. A saner default would be: if no user is specified, we assume the user is using postgres' ident authentication, and does not actually want to explicitly specify a user, instead using the operating system's user.
