### PR TITLE
Fix #10 : load Dotenv to work with .env configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Or install it yourself as:
     $ gem install capistrano3-postgres
 
 ## Usage
+
+Capistrano3::Postgres supports [Dotenv](https://github.com/bkeepers/dotenv) gem and automatically loads environment variables from `.env` files if they are used in the project.
+
 ```ruby
     # Capfile
 


### PR DESCRIPTION
Load [Dotenv](https://github.com/bkeepers/dotenv) gem if it exists to correctly process configuration files with ENV variables for local and remote servers.

Written in such a way that it is easy to extend functionality to work with other gems like Figaro.
