### PR TITLE
Bug fix: do not break command to multiple strings

### DIFF
--- a/lib/capistrano3/tasks/postgres.rb
+++ b/lib/capistrano3/tasks/postgres.rb
@@ -200,10 +200,7 @@ namespace :postgres do
     <<-RUBY.strip
       begin
         require 'dotenv'
-        Dotenv.load(
-          File.expand_path(".env.#{env}"),
-          File.expand_path('.env')
-        )
+        Dotenv.load(File.expand_path(".env.#{env}"), File.expand_path('.env'))
       rescue LoadError
       end
 


### PR DESCRIPTION
When sshkit santitizes the command (https://github.com/capistrano/sshkit/blob/master/lib/sshkit/command.rb#L229-L232) it adds `"; "` at the end of every line (except for the last one).

In this case it provides invalid code:

```
begin; require 'dotenv'; Dotenv.load(; File.expand_path('.env.production'),; File.expand_path('.env'); ); rescue LoadError; end; require 'erb';
```

That's why it's better removing excessive line breaks here.
