### PR TITLE
Fix quotes in multiline task

### DIFF
--- a/lib/capistrano3/tasks/postgres.rb
+++ b/lib/capistrano3/tasks/postgres.rb
@@ -200,7 +200,7 @@ namespace :postgres do
     <<-RUBY.strip
       begin
         require 'dotenv'
-        Dotenv.load(File.expand_path(".env.#{env}"), File.expand_path('.env'))
+        Dotenv.load(File.expand_path('.env.#{env}'), File.expand_path('.env'))
       rescue LoadError
       end
 


### PR DESCRIPTION
One more thing here. I do not know why, but sshkit removes double quotes around `.env.production` leaving code that is still invalid:

```
Dotenv.load(File.expand_path(.env.production), ...)
```

with single quotes it works fine

```
Dotenv.load(File.expand_path('.env.production'), ...)
```
