### PR TITLE
Fix to passing of env to Figaro in `env_variables_loader_code`

### DIFF
--- a/lib/capistrano3/tasks/postgres.rb
+++ b/lib/capistrano3/tasks/postgres.rb
@@ -208,7 +208,7 @@ namespace :postgres do
         require 'figaro'
         config = File.expand_path('../config/application.yml', __FILE__)
 
-        Figaro.application = Figaro::Application.new(environment: env, path: config)
+        Figaro.application = Figaro::Application.new(environment: '#{env}', path: config)
         Figaro.load
       rescue LoadError
       end


### PR DESCRIPTION
The string generated by `env_variables_loader_code` was attempting to use the `env` parameter within the generated string without first turning `env` into a string itself.  The result was the following exception when attempting to run (in a project that has neither Dotenv nor Figaro included):

```
$ bundle exec cap production postgres:replicate --trace
** Invoke production (first_time)
** Execute production
** Invoke load:defaults (first_time)
** Execute load:defaults
** Invoke bundler:map_bins (first_time)
** Execute bundler:map_bins
** Invoke deploy:set_rails_env (first_time)
** Execute deploy:set_rails_env
** Invoke deploy:set_linked_dirs (first_time)
** Execute deploy:set_linked_dirs
** Invoke deploy:set_rails_env 
** Invoke rbenv:validate (first_time)
** Execute rbenv:validate
** Invoke rbenv:map_bins (first_time)
** Execute rbenv:map_bins
** Invoke postgres:replicate (first_time)
** Execute postgres:replicate
** Invoke postgres:backup:create (first_time)
** Invoke postgres:backup:ensure_remote_dirs (first_time)
** Execute postgres:backup:ensure_remote_dirs
00:00 postgres:backup:ensure_remote_dirs
      01 mkdir -p /home/web/apps/app_name/shared/postgres_backup
    ✔ 01 redacted-user@redacted-server.com 0.462s
** Execute postgres:backup:create
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as redacted-user@redacted-server.com: Exception while executing as redacted-user@redacted-server.com: bundle exit status: 1
bundle stdout: -e:11:in `<main>': undefined local variable or method `env' for main:Object (NameError)
bundle stderr: Nothing written
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
SSHKit::Runner::ExecuteError: Exception while executing as redacted-user@redacted-server.com: bundle exit status: 1
bundle stdout: -e:11:in `<main>': undefined local variable or method `env' for main:Object (NameError)
bundle stderr: Nothing written
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
SSHKit::Command::Failed: bundle exit status: 1
bundle stdout: -e:11:in `<main>': undefined local variable or method `env' for main:Object (NameError)
bundle stderr: Nothing written
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/command.rb:100:in `exit_status='
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/netssh.rb:148:in `execute_command'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:141:in `block in create_command_and_execute'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:141:in `tap'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:141:in `create_command_and_execute'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:60:in `capture'
...ruby-2.3.1/gems/capistrano3-postgres-0.2.2/lib/capistrano3/tasks/postgres.rb:150:in `block (2 levels) in grab_remote_database_config'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:85:in `within'
...ruby-2.3.1/gems/capistrano3-postgres-0.2.2/lib/capistrano3/tasks/postgres.rb:140:in `block in grab_remote_database_config'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:29:in `instance_exec'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/backends/abstract.rb:29:in `run'
...ruby-2.3.1/gems/sshkit-1.11.4/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
Tasks: TOP => postgres:backup:create
```

This fix does the correct insertion of `env` as a string argument to `Figaro::Application.new`.